### PR TITLE
Fix correct chat history

### DIFF
--- a/ChatApp/interface/empty_stub_interface.py
+++ b/ChatApp/interface/empty_stub_interface.py
@@ -23,8 +23,10 @@ class EmptyStubInterface:
     ):
         logging.info("hi there")
         logging.info("-" * 100)
-        # yield chatbot,history,"Empty context."
-        yield [[text, "No Model Found"]], [], "No Model Found"
+
+        history.append([text, f"[Empty Model] You typed: {text}"])
+        yield history, history, "No Model Found"
+        # yield [[text, "No Model Found"]], [], "No Model Found"
 
     def retry(
         self,

--- a/ChatApp/interface/hddr_llama_onnx_interface.py
+++ b/ChatApp/interface/hddr_llama_onnx_interface.py
@@ -224,7 +224,7 @@ short answers are usually best"
         pos = np.array(0)
 
         x = (
-            self.embeddingLayer(torch.tensor(input_ids))
+            self.embeddingLayer(input_ids.clone().detach())
             .detach()
             .cpu()
             .numpy()
@@ -342,9 +342,8 @@ short answers are usually best"
                 if "[|AI|]" in x:
                     x = x[: x.index("[|AI|]")].strip()
                 x = x.strip()
-                a, b = [[y[0], convert_to_markdown(y[1])] for y in history] + [
-                    [text, convert_to_markdown(x)]
-                ], history + [[text, x]]
+                history.append([text, x])
+                a, b = [[y[0], convert_to_markdown(y[1])] for y in history], history
                 yield a, b, "Generating..."
             if shared_state.interrupted:
                 shared_state.recover()


### PR DESCRIPTION
In the interface, every time a text is generated, the history of the chat is deleted.
This fix appends the model response to the history to show all interactions.